### PR TITLE
特定の実行環境でテクスチャの読み込みができていない事象について

### DIFF
--- a/src/script/effekseer-emitter.js
+++ b/src/script/effekseer-emitter.js
@@ -26,22 +26,11 @@ EffekseerEmitter.prototype.initialize = function() {
     {
         theApp = this.app;
         var redirectFuc = function redirect(src) {
-            console.log(src);
             var srcs = src.split('/');
             var filename = srcs[srcs.length-1];
-            var assets = theApp.assets.findAll(filename); 
-            
-            if(assets.length === 0) return src;
-            
-            for(var i = 0; i < assets.length; i += 1)
-            {
-                var url = assets[i].getFileUrl();
-                if(url.includes(src))
-                {
-                    return url;
-                }
-            }
-            return src;
+            var asset = theApp.assets.find(filename);
+            if(!asset) return src;
+            return asset.getFileUrl();
         };
 
 


### PR DESCRIPTION
### 発生していた問題
https://playcanv.as/など、https://launch.playcanvas.com/ で始まるURLではない場合アセットの読み込み時にリソースをうまく読み込めていない問題を修正

### 修正前
![ScreenShot 117](https://user-images.githubusercontent.com/39250588/75741076-d0312200-5d4c-11ea-80a0-76be25553b49.jpg)
PlayCanvasのホスティングを使用し、実行をした際にテクスチャが読み込めていなかった
https://playcanv.as/p/zpYI24xM/

### 修正後
![ScreenShot 118](https://user-images.githubusercontent.com/39250588/75741381-be03b380-5d4d-11ea-9fa5-bb8528f6146d.jpg)
テクスチャの読み込みを行う事ができた
https://playcanv.as/p/uErUtIFA/

### 変更点

アセットを読み込む為の関数を下記に変更

`pc.app.assets.findAll` → `pc.app.assets.find`

APIについて
https://developer.playcanvas.com/en/api/pc.Asset.html
